### PR TITLE
Add IndexMut traits.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "ascii"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 
 description = "`Ascii` type and related functionality, previously in `std::ascii`."


### PR DESCRIPTION
Also adds a direct usize index (since it's not variable-length encoded, there's no reason not to do this here).

I'd add that it's a bit confusing to me why we are declaring the Index traits for AsciiString at all; can't we just let Deref delegate everything?  I didn't change it because I suppose at this point it's backwards-incompatible to fix, but that seems like a cleaner design.